### PR TITLE
Remove async wait for card initialization

### DIFF
--- a/card_discussion.html
+++ b/card_discussion.html
@@ -372,9 +372,8 @@
     function drawCard(){ if(game) game.drawCard(); }
     function resetDeck(){ if(game) game.resetDeck(); }
 
-    window.addEventListener('load', async ()=>{
+    window.addEventListener('load', ()=>{
       game = new DiscussionCardGame();
-      while(game.cards.length===0){ await new Promise(r=>setTimeout(r,100)); }
       document.getElementById('cardContainer').classList.add('visible');
       document.getElementById('discussionCard').addEventListener('click', ()=>{
         const cardEl = document.getElementById('discussionCard');


### PR DESCRIPTION
## Summary
- make the card discussion initialization synchronous now that cards are immediately available
- show the card container as soon as the game instance is created

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d96605dee0832e9bbce7582d542d6d