### PR TITLE
Add theme selection modal to discussion cards

### DIFF
--- a/card_discussion.html
+++ b/card_discussion.html
@@ -180,6 +180,99 @@
       border:2px solid rgba(255,255,255,0.6);
     }
 
+    .modal-overlay{
+      position:fixed;
+      inset:0;
+      background:rgba(8,33,41,0.75);
+      backdrop-filter:blur(6px);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:20px;
+      opacity:0;
+      pointer-events:none;
+      transition:opacity .3s ease;
+      z-index:1000;
+    }
+
+    .modal-overlay.visible{ opacity:1; pointer-events:auto; }
+
+    .modal-content{
+      background:var(--surface);
+      color:var(--text);
+      max-width:520px;
+      width:100%;
+      border-radius:18px;
+      padding:30px;
+      box-shadow:0 20px 45px rgba(0,0,0,0.25);
+      display:flex;
+      flex-direction:column;
+      gap:20px;
+    }
+
+    .modal-title{
+      font-size:1.6rem;
+      font-weight:700;
+      text-align:center;
+    }
+
+    .modal-description{
+      font-size:1rem;
+      line-height:1.5;
+      text-align:center;
+      color:#445869;
+    }
+
+    .select-all{
+      display:flex;
+      justify-content:flex-end;
+      font-weight:600;
+      color:#2b4d5c;
+    }
+
+    .theme-options{
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+      gap:12px;
+      max-height:240px;
+      overflow:auto;
+      padding-right:4px;
+    }
+
+    .theme-option{
+      background:var(--surface-muted);
+      border-radius:14px;
+      padding:12px 14px;
+      display:flex;
+      align-items:center;
+      gap:10px;
+      font-weight:600;
+      border:1px solid rgba(0,133,124,0.15);
+      box-shadow:0 4px 12px rgba(11,49,74,0.06);
+      transition:transform .2s ease, box-shadow .2s ease;
+    }
+
+    .theme-option input{ accent-color:var(--primary-1); width:18px; height:18px; }
+
+    .theme-option:hover{ transform:translateY(-2px); box-shadow:0 8px 20px rgba(11,49,74,0.12); }
+
+    .modal-actions{
+      display:flex;
+      justify-content:center;
+      gap:12px;
+      flex-wrap:wrap;
+    }
+
+    .modal-error{
+      color:#b91c1c;
+      font-weight:600;
+      text-align:center;
+      min-height:20px;
+    }
+
+    #openThemeSelector{ background:var(--surface); color:var(--primary-1); border:2px solid rgba(0,133,124,0.35); }
+    #openThemeSelector:hover{ color:var(--text-inverse); background:var(--primary-grad); }
+
     .floating-particles{
       position:fixed; inset:0; pointer-events:none; z-index:-1;
     }
@@ -241,6 +334,22 @@
   <div class="controls">
     <button class="btn btn-primary" onclick="drawCard()">Nouvelle Carte</button>
     <button class="btn btn-secondary" onclick="resetDeck()">Réinitialiser</button>
+    <button class="btn" id="openThemeSelector">Choisir les thématiques</button>
+  </div>
+
+  <div class="modal-overlay" id="themeSelectorModal">
+    <div class="modal-content">
+      <h2 class="modal-title">Choisissez vos thématiques</h2>
+      <p class="modal-description">Sélectionnez les thématiques que vous souhaitez voir apparaître dans votre partie. Vous pourrez modifier ce choix à tout moment.</p>
+      <div class="select-all">
+        <label for="selectAllThemes"><input type="checkbox" id="selectAllThemes" checked> Tout sélectionner</label>
+      </div>
+      <div class="theme-options" id="themeOptions"></div>
+      <div class="modal-error" id="themeError"></div>
+      <div class="modal-actions">
+        <button class="btn btn-primary" id="applyThemeSelection">Valider la sélection</button>
+      </div>
+    </div>
   </div>
 
   <!-- Données XML intégrées -->
@@ -324,7 +433,8 @@
   <script>
     class DiscussionCardGame {
       constructor(){
-        this.cards = this.loadCardsFromXML();
+        this.allCards = this.loadCardsFromXML();
+        this.cards = [...this.allCards];
         this.availableCards = [...this.cards];
         this.usedCards = [];
         this.currentCard = null;
@@ -339,15 +449,25 @@
         this.counterEl = document.getElementById('cardCounter');
         this.cardContainerEl = document.getElementById('cardContainer');
         this.floatingParticlesContainer = document.querySelector('.floating-particles');
+        this.themeModalEl = document.getElementById('themeSelectorModal');
+        this.themeOptionsEl = document.getElementById('themeOptions');
+        this.themeErrorEl = document.getElementById('themeError');
+        this.selectAllEl = document.getElementById('selectAllThemes');
+        this.applyThemeSelectionBtn = document.getElementById('applyThemeSelection');
+        this.openThemeSelectorBtn = document.getElementById('openThemeSelector');
+        this.activeCategories = new Set(this.cards.map(card=>card.category));
         this.updateCounter();
         this.createFloatingParticles();
         this.prepareWelcomeCard();
+        this.populateThemeOptions();
+        this.bindThemeSelectorEvents();
       }
 
       prepareWelcomeCard(){
         this.currentCard = this.welcomeCard;
-        this.cardCategoryEl.textContent = this.welcomeCard.category;
-        this.cardContentEl.textContent = this.welcomeCard.content;
+        if(this.cardEl){ this.cardEl.classList.remove('flipping'); }
+        if(this.cardCategoryEl){ this.cardCategoryEl.textContent = this.welcomeCard.category; }
+        if(this.cardContentEl){ this.cardContentEl.textContent = this.welcomeCard.content; }
       }
 
       loadCardsFromXML(){
@@ -423,11 +543,7 @@
         this.availableCards=[...this.cards];
         this.usedCards=[];
         this.updateCounter();
-        this.cardEl.classList.remove('flipping');
-        setTimeout(()=>{
-          this.cardCategoryEl.textContent='Bienvenue';
-          this.cardContentEl.textContent='Cliquez sur le tas de cartes pour découvrir votre première question de discussion !';
-        },400);
+        this.prepareWelcomeCard();
       }
 
       showNoMoreCards(){
@@ -451,6 +567,109 @@
           container.appendChild(p);
         }
       }
+
+      getAllCategories(){
+        return Array.from(new Set(this.allCards.map(card=>card.category))).sort();
+      }
+
+      populateThemeOptions(){
+        if(!this.themeOptionsEl) return;
+        const categories = this.getAllCategories();
+        this.themeOptionsEl.innerHTML='';
+        categories.forEach(category=>{
+          const optionId = `theme-${category.toLowerCase().replace(/[^a-z0-9]+/g,'-')}`;
+          const label = document.createElement('label');
+          label.className='theme-option';
+          label.setAttribute('for', optionId);
+
+          const checkbox = document.createElement('input');
+          checkbox.type='checkbox';
+          checkbox.id = optionId;
+          checkbox.value = category;
+          checkbox.checked = this.activeCategories.has(category);
+
+          const span = document.createElement('span');
+          span.textContent = category;
+
+          label.appendChild(checkbox);
+          label.appendChild(span);
+          this.themeOptionsEl.appendChild(label);
+        });
+        this.syncSelectAllCheckbox();
+      }
+
+      syncSelectAllCheckbox(){
+        if(!this.selectAllEl || !this.themeOptionsEl) return;
+        const checkboxes = Array.from(this.themeOptionsEl.querySelectorAll('input[type="checkbox"]'));
+        if(checkboxes.length===0){
+          this.selectAllEl.checked = false;
+          return;
+        }
+        const allChecked = checkboxes.every(cb=>cb.checked);
+        const noneChecked = checkboxes.every(cb=>!cb.checked);
+        this.selectAllEl.checked = allChecked;
+        if(this.themeErrorEl && !noneChecked){
+          this.themeErrorEl.textContent='';
+        }
+      }
+
+      bindThemeSelectorEvents(){
+        if(this.openThemeSelectorBtn){
+          this.openThemeSelectorBtn.addEventListener('click', ()=> this.showThemeSelector());
+        }
+        if(this.applyThemeSelectionBtn){
+          this.applyThemeSelectionBtn.addEventListener('click', ()=>{
+            const selected = this.getSelectedThemes();
+            if(selected.length===0){
+              if(this.themeErrorEl){ this.themeErrorEl.textContent='Sélectionnez au moins une thématique pour commencer.'; }
+              return;
+            }
+            this.applyThemeSelection(selected);
+            this.hideThemeSelector();
+          });
+        }
+        if(this.selectAllEl){
+          this.selectAllEl.addEventListener('change', (event)=>{
+            const checked = event.target.checked;
+            if(!this.themeOptionsEl) return;
+            this.themeOptionsEl.querySelectorAll('input[type="checkbox"]').forEach(cb=>{ cb.checked = checked; });
+            this.syncSelectAllCheckbox();
+          });
+        }
+        if(this.themeOptionsEl){
+          this.themeOptionsEl.addEventListener('change', ()=> this.syncSelectAllCheckbox());
+        }
+      }
+
+      getSelectedThemes(){
+        if(!this.themeOptionsEl) return [];
+        return Array.from(this.themeOptionsEl.querySelectorAll('input[type="checkbox"]:checked')).map(cb=>cb.value);
+      }
+
+      applyThemeSelection(selectedCategories){
+        this.activeCategories = new Set(selectedCategories);
+        this.cards = this.allCards.filter(card=>this.activeCategories.has(card.category));
+        this.availableCards = [...this.cards];
+        this.usedCards = [];
+        this.updateCounter();
+        this.prepareWelcomeCard();
+        this.populateThemeOptions();
+      }
+
+      showThemeSelector(){
+        if(this.themeModalEl){
+          this.populateThemeOptions();
+          if(this.themeErrorEl){ this.themeErrorEl.textContent=''; }
+          this.themeModalEl.classList.add('visible');
+        }
+      }
+
+      hideThemeSelector(){
+        if(this.themeModalEl){
+          this.themeModalEl.classList.remove('visible');
+        }
+        if(this.themeErrorEl){ this.themeErrorEl.textContent=''; }
+      }
     }
 
     let game;
@@ -468,6 +687,7 @@
           else{ game.cardEl.classList.add('flipping'); }
         }
       });
+      game.showThemeSelector();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add a theme selection modal so players can choose which categories appear in the deck
- extend the game logic to filter available cards based on the chosen themes and keep the selector accessible from controls
- ensure deck resets return to the welcome card after updating the active themes

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d987c5ecc8832e8542f4e5fab46f2d