### PR TITLE
Add JSON session persistence to discussion card game

### DIFF
--- a/card_discussion.html
+++ b/card_discussion.html
@@ -50,7 +50,11 @@
     <button class="btn btn-primary" onclick="drawCard()">Nouvelle Carte</button>
     <button class="btn btn-secondary" onclick="resetDeck()">Réinitialiser</button>
     <button class="btn" id="openThemeSelector">Choisir les thématiques</button>
+    <button class="btn" id="saveSession" type="button">Enregistrer la session</button>
+    <button class="btn" id="loadSession" type="button">Charger une session</button>
   </div>
+
+  <input type="file" id="sessionFileInput" accept="application/json" class="visually-hidden" aria-hidden="true" tabindex="-1">
 
   <div class="modal-overlay" id="themeSelectorModal" aria-hidden="true">
     <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="themeSelectorTitle">


### PR DESCRIPTION
## Summary
- add controls in the UI to export and import the current deck state as JSON
- include card identifiers and active themes when serializing the session to prevent re-drawing used cards
- restore deck availability, used cards, and theme selections when loading a saved session

## Testing
- not run (front-end only)


------
https://chatgpt.com/codex/tasks/task_e_68d98e9672c0832e97dc640ca1caec60