### PR TITLE
Improve mobile layout for discussion cards

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -99,9 +99,12 @@ body{
 .deck-card:nth-child(3){ transform: translateZ(-4px) rotate(-1deg); }
 
 .card-container{
-  width:350px;height:200px;perspective:1000px;
+  width:350px;
+  height:260px;
+  perspective:1000px;
   transform:translateX(-50px);
-  opacity:0;transition:all .5s ease;
+  opacity:0;
+  transition:all .5s ease;
   position:relative;
 }
 .card-container.visible{ opacity:1; transform:translateX(0); }
@@ -179,8 +182,13 @@ body{
 }
 
 .card-content{
-  color:var(--text); font-size:1.1rem; line-height:1.6; font-weight:500;
+  color:var(--text);
+  font-size:1.05rem;
+  line-height:1.65;
+  font-weight:500;
   text-shadow: 1px 1px 2px rgba(0,0,0,0.06);
+  overflow-y:auto;
+  padding-right:4px;
 }
 
 .controls{
@@ -384,8 +392,106 @@ body{
 
 @media (max-width:768px){
   .title{ font-size:2rem; margin-bottom:2rem; }
-  .game-container{ height:400px; flex-direction:column; gap:30px; }
+  .game-container{ height:auto; flex-direction:column; gap:24px; }
   .card-deck{ position:relative; right:auto; }
-  .card-container{ width:300px; height:180px; transform:none; }
+  .card-container{ width:320px; height:240px; transform:none; }
   .card-container.visible{ transform:none; }
+}
+
+@media (max-width:600px){
+  body{
+    justify-content:flex-start;
+    padding:16px 14px 32px;
+  }
+
+  .title{
+    font-size:1.75rem;
+    margin-bottom:1.5rem;
+    line-height:1.3;
+  }
+
+  .game-container{
+    width:100%;
+    gap:18px;
+    align-items:stretch;
+  }
+
+  .card-deck{
+    margin:0 auto;
+    width:110px;
+    height:165px;
+    transform-origin:center;
+  }
+
+  .deck-card{
+    border-radius:16px;
+  }
+
+  .deck-counter{
+    top:-12px;
+    right:-12px;
+  }
+
+  .card-container{
+    width:100%;
+    max-width:100%;
+    height:auto;
+    min-height:300px;
+    transform:none;
+  }
+
+  .card-container.visible{
+    transform:none;
+  }
+
+  .discussion-card{
+    min-height:300px;
+  }
+
+  .card-face{
+    padding:22px 20px;
+  }
+
+  .card-front-text{
+    font-size:0.9rem;
+  }
+
+  .card-category{
+    margin-bottom:14px;
+  }
+
+  .card-content{
+    font-size:1rem;
+    line-height:1.6;
+    max-height:calc(60vh - 140px);
+  }
+
+  .expert-button{
+    top:12px;
+    right:12px;
+    width:44px;
+    height:44px;
+  }
+
+  .controls{
+    width:100%;
+    flex-direction:column;
+    align-items:stretch;
+    gap:14px;
+  }
+
+  .controls .btn{
+    width:100%;
+  }
+
+  .modal-content{
+    max-width:100%;
+    padding:24px 20px;
+    max-height:90vh;
+    overflow:auto;
+  }
+
+  .theme-options{
+    grid-template-columns:1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- raise the discussion card container height and allow the content area to scroll so long prompts stay readable
- refine tablet and mobile breakpoints to stack the deck, card, and controls with full-width buttons
- tighten modal and expert button spacing for smaller viewports to keep the interface comfortable on phones

## Testing
- Manual verification in Chromium mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68d99aa24658832eb95d33c3b583f3c7