### PR TITLE
Enable scrolling for overflowing card content

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -145,7 +145,7 @@ body{
   padding:30px; display:flex; flex-direction:column;
   align-items:center; justify-content:center; text-align:center;
   box-shadow:0 15px 40px var(--shadow-1);
-  backface-visibility:hidden; overflow:hidden;
+  backface-visibility:hidden;
 }
 
 .card-front{
@@ -158,6 +158,11 @@ body{
   background: linear-gradient(145deg, var(--surface), var(--surface-muted));
   color:var(--text);
   transform: rotateY(180deg);
+  align-items:stretch;
+  justify-content:flex-start;
+  text-align:left;
+  padding:30px 26px 26px;
+  gap:18px;
 }
 
 .card-front-content{
@@ -188,7 +193,31 @@ body{
   font-weight:500;
   text-shadow: 1px 1px 2px rgba(0,0,0,0.06);
   overflow-y:auto;
-  padding-right:4px;
+  padding-right:8px;
+  max-height:calc(100% - 60px);
+}
+
+.card-content:focus{
+  outline:2px solid var(--accent-1);
+  outline-offset:2px;
+}
+
+.card-content::-webkit-scrollbar{
+  width:6px;
+}
+
+.card-content::-webkit-scrollbar-track{
+  background:rgba(0,0,0,0.05);
+  border-radius:10px;
+}
+
+.card-content::-webkit-scrollbar-thumb{
+  background:var(--primary-2);
+  border-radius:10px;
+}
+
+.card-content::-webkit-scrollbar-thumb:hover{
+  background:var(--primary-1);
 }
 
 .controls{


### PR DESCRIPTION
## Summary
- adjust the card back layout so long text stays readable and aligned from the top
- cap the card content height and enable a custom scrollbar with focus styling for accessibility

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d99d0b3a0c832eb88428dc0cc2e6b8