### PR TITLE
Regrouper les actions avancées dans un menu burger

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -234,6 +234,93 @@ body{
   margin-top:3rem; display:flex; gap:20px; flex-wrap:wrap; justify-content:center;
 }
 
+.controls-menu{
+  position:relative;
+}
+
+.btn-menu-toggle{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  background:var(--surface);
+  color:var(--primary-1);
+  text-transform:none;
+  letter-spacing:0;
+  padding:15px 24px;
+  box-shadow:0 8px 18px rgba(0,0,0,0.2);
+}
+
+.btn-menu-toggle:hover,
+.btn-menu-toggle:focus{
+  background:var(--surface-muted);
+  color:var(--primary-2);
+}
+
+.menu-toggle-icon{
+  position:relative;
+  width:22px;
+  height:2px;
+  background:currentColor;
+  border-radius:2px;
+}
+
+.menu-toggle-icon::before,
+.menu-toggle-icon::after{
+  content:"";
+  position:absolute;
+  left:0;
+  width:22px;
+  height:2px;
+  background:currentColor;
+  border-radius:2px;
+}
+
+.menu-toggle-icon::before{ top:-6px; }
+.menu-toggle-icon::after{ top:6px; }
+
+.menu-dropdown{
+  position:absolute;
+  right:0;
+  top:calc(100% + 12px);
+  background:var(--surface);
+  border-radius:16px;
+  padding:16px;
+  box-shadow:0 18px 40px rgba(0,0,0,0.25);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  min-width:240px;
+  opacity:0;
+  transform:translateY(-12px);
+  pointer-events:none;
+  transition:opacity .2s ease, transform .2s ease;
+  z-index:30;
+}
+
+.controls-menu.open .menu-dropdown{
+  opacity:1;
+  transform:translateY(0);
+  pointer-events:auto;
+}
+
+.menu-action{
+  justify-content:flex-start;
+  width:100%;
+  background:var(--surface-muted);
+  color:var(--text);
+  text-transform:none;
+  letter-spacing:0;
+  padding:12px 18px;
+  box-shadow:none;
+  border-radius:12px;
+}
+
+.menu-action:hover,
+.menu-action:focus{
+  background:rgba(0,133,124,0.12);
+  color:var(--primary-1);
+}
+
 .btn{
   padding:15px 30px; border:none; border-radius:50px; font-size:1rem; font-weight:700; cursor:pointer;
   transition:all .3s ease; text-transform:uppercase; letter-spacing:1px;

--- a/card_discussion.html
+++ b/card_discussion.html
@@ -49,10 +49,18 @@
 
   <div class="controls">
     <button class="btn btn-primary" onclick="drawCard()">Nouvelle Carte</button>
-    <button class="btn btn-secondary" onclick="resetDeck()">Réinitialiser</button>
-    <button class="btn" id="openThemeSelector">Choisir les thématiques</button>
-    <button class="btn" id="saveSession" type="button">Enregistrer la session</button>
-    <button class="btn" id="loadSession" type="button">Charger une session</button>
+    <div class="controls-menu">
+      <button class="btn btn-menu-toggle" id="advancedMenuToggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="advancedMenu">
+        <span class="menu-toggle-icon" aria-hidden="true"></span>
+        <span class="menu-toggle-label">Plus d'actions</span>
+      </button>
+      <div class="menu-dropdown" id="advancedMenu" role="menu">
+        <button class="btn menu-action" role="menuitem" onclick="resetDeck()">Réinitialiser</button>
+        <button class="btn menu-action" id="openThemeSelector" type="button" role="menuitem">Choisir les thématiques</button>
+        <button class="btn menu-action" id="saveSession" type="button" role="menuitem">Enregistrer la session</button>
+        <button class="btn menu-action" id="loadSession" type="button" role="menuitem">Charger une session</button>
+      </div>
+    </div>
   </div>
 
   <input type="file" id="sessionFileInput" accept="application/json" class="visually-hidden" aria-hidden="true" tabindex="-1">

--- a/card_discussion.js
+++ b/card_discussion.js
@@ -42,6 +42,9 @@ class DiscussionCardGame {
     this.saveSessionBtn = document.getElementById('saveSession');
     this.loadSessionBtn = document.getElementById('loadSession');
     this.sessionFileInput = document.getElementById('sessionFileInput');
+    this.advancedMenuToggle = document.getElementById('advancedMenuToggle');
+    this.advancedMenu = document.getElementById('advancedMenu');
+    this.advancedMenuWrapper = this.advancedMenuToggle ? this.advancedMenuToggle.closest('.controls-menu') : null;
     this.cardStatusEl = document.getElementById('cardStatus');
     this.themeTriggerElement = null;
     this.expertTriggerElement = null;
@@ -56,6 +59,7 @@ class DiscussionCardGame {
     this.bindExpertAdviceEvents();
     this.bindMasteryEvents();
     this.bindPersistenceEvents();
+    this.bindAdvancedMenuEvents();
     this.bindAccessibilityInteractions();
     this.setExpertButtonState(false);
   }
@@ -137,6 +141,82 @@ class DiscussionCardGame {
         }
       });
     }
+  }
+
+  bindAdvancedMenuEvents(){
+    if(!this.advancedMenuToggle || !this.advancedMenu || !this.advancedMenuWrapper) return;
+
+    const closeMenu = (restoreFocus=false)=>{
+      if(!this.advancedMenuWrapper.classList.contains('open')) return;
+      this.advancedMenuWrapper.classList.remove('open');
+      this.advancedMenuToggle.setAttribute('aria-expanded','false');
+      if(restoreFocus){
+        this.advancedMenuToggle.focus();
+      }
+    };
+
+    const openMenu = ()=>{
+      this.advancedMenuWrapper.classList.add('open');
+      this.advancedMenuToggle.setAttribute('aria-expanded','true');
+    };
+
+    const toggleMenu = ()=>{
+      const isOpen = this.advancedMenuWrapper.classList.toggle('open');
+      this.advancedMenuToggle.setAttribute('aria-expanded', String(isOpen));
+      if(isOpen){
+        const firstAction = this.advancedMenu.querySelector('button');
+        if(firstAction){
+          firstAction.focus();
+        }
+      }
+    };
+
+    this.advancedMenuToggle.addEventListener('click', event=>{
+      event.stopPropagation();
+      toggleMenu();
+    });
+
+    this.advancedMenuToggle.addEventListener('keydown', event=>{
+      if(event.key==='ArrowDown' || event.key==='Enter' || event.key===' '){
+        event.preventDefault();
+        if(!this.advancedMenuWrapper.classList.contains('open')){
+          openMenu();
+        }
+        const firstAction = this.advancedMenu.querySelector('button');
+        if(firstAction){
+          firstAction.focus();
+        }
+      }
+    });
+
+    this.advancedMenu.addEventListener('click', event=>{
+      const target = event.target;
+      if(target instanceof HTMLElement && target.matches('button')){
+        closeMenu(true);
+      }
+    });
+
+    this.advancedMenu.addEventListener('keydown', event=>{
+      if(event.key==='Escape'){
+        event.stopPropagation();
+        closeMenu(true);
+      }
+    });
+
+    document.addEventListener('click', event=>{
+      const target = event.target;
+      if(target instanceof Node && this.advancedMenuWrapper.contains(target)){
+        return;
+      }
+      closeMenu(false);
+    });
+
+    document.addEventListener('keydown', event=>{
+      if(event.key==='Escape' && this.advancedMenuWrapper.classList.contains('open')){
+        event.stopPropagation();
+        closeMenu(true);
+      }
+    });
   }
 
   _takeRandomCard(){
@@ -559,7 +639,11 @@ class DiscussionCardGame {
 
   showThemeSelector(){
     if(this.themeModalEl){
-      this.themeTriggerElement = document.activeElement;
+      if(this.advancedMenuWrapper && this.advancedMenuWrapper.classList.contains('open')){
+        this.themeTriggerElement = this.advancedMenuToggle;
+      }else{
+        this.themeTriggerElement = document.activeElement;
+      }
       this.populateThemeOptions();
       if(this.themeErrorEl){ this.themeErrorEl.textContent=''; }
       this.themeModalEl.classList.add('visible');


### PR DESCRIPTION
## Summary
- déplacer les actions secondaires dans un menu burger accessible autour des contrôles principaux
- ajouter les styles du bouton hamburger et du panneau déroulant
- connecter la logique JavaScript pour gérer l’ouverture/fermeture du menu et le focus clavier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da301e22ec832eaab7328bac51bf32