### PR TITLE
Refine burger menu placement and styling

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -241,12 +241,15 @@ body{
 .btn-menu-toggle{
   display:flex;
   align-items:center;
-  gap:12px;
+  justify-content:center;
+  width:56px;
+  height:56px;
+  padding:0;
+  border-radius:50%;
   background:var(--surface);
   color:var(--primary-1);
   text-transform:none;
   letter-spacing:0;
-  padding:15px 24px;
   box-shadow:0 8px 18px rgba(0,0,0,0.2);
 }
 
@@ -254,6 +257,12 @@ body{
 .btn-menu-toggle:focus{
   background:var(--surface-muted);
   color:var(--primary-2);
+}
+
+.controls .btn-menu-toggle{
+  align-self:flex-end;
+  width:56px;
+  height:56px;
 }
 
 .menu-toggle-icon{
@@ -319,6 +328,20 @@ body{
 .menu-action:focus{
   background:rgba(0,133,124,0.12);
   color:var(--primary-1);
+}
+
+@media (min-width:992px){
+  .controls-menu{
+    position:fixed;
+    top:24px;
+    right:24px;
+    z-index:120;
+  }
+
+  .controls-menu .menu-dropdown{
+    top:calc(100% + 16px);
+    right:0;
+  }
 }
 
 .btn{
@@ -658,6 +681,20 @@ body{
 
   .controls .btn{
     width:100%;
+  }
+
+  .controls-menu{
+    align-self:flex-end;
+  }
+
+  .controls .btn-menu-toggle{
+    width:56px;
+  }
+
+  .controls-menu .menu-dropdown{
+    width:min(260px, 88vw);
+    right:0;
+    left:auto;
   }
 
   .modal-content{

--- a/card_discussion.html
+++ b/card_discussion.html
@@ -50,9 +50,9 @@
   <div class="controls">
     <button class="btn btn-primary" onclick="drawCard()">Nouvelle Carte</button>
     <div class="controls-menu">
-      <button class="btn btn-menu-toggle" id="advancedMenuToggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="advancedMenu">
+      <button class="btn btn-menu-toggle" id="advancedMenuToggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="advancedMenu" aria-label="Ouvrir le menu d'actions">
         <span class="menu-toggle-icon" aria-hidden="true"></span>
-        <span class="menu-toggle-label">Plus d'actions</span>
+        <span class="visually-hidden">Menu d'actions</span>
       </button>
       <div class="menu-dropdown" id="advancedMenu" role="menu">
         <button class="btn menu-action" role="menuitem" onclick="resetDeck()">Réinitialiser</button>


### PR DESCRIPTION
## Summary
- display the advanced menu toggle as an icon-only control with a screen-reader label
- restyle the burger button and reposition it to the top-right on desktop while keeping a mobile-friendly layout

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da33101fdc832e88cdafe54a860741