### PR TITLE
Aligne l'icône du menu burger

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -267,25 +267,23 @@ body{
 
 .menu-toggle-icon{
   position:relative;
+  display:block;
   width:22px;
-  height:2px;
-  background:currentColor;
-  border-radius:2px;
+  height:14px;
 }
 
-.menu-toggle-icon::before,
-.menu-toggle-icon::after{
+.menu-toggle-icon::before{
   content:"";
   position:absolute;
+  top:50%;
   left:0;
   width:22px;
   height:2px;
   background:currentColor;
   border-radius:2px;
+  transform:translateY(-50%);
+  box-shadow:0 -6px 0 currentColor, 0 6px 0 currentColor;
 }
-
-.menu-toggle-icon::before{ top:-6px; }
-.menu-toggle-icon::after{ top:6px; }
 
 .menu-dropdown{
   position:absolute;


### PR DESCRIPTION
## Summary
- recentre les trois traits de l'icône du menu burger en recalculant leur position
- garantit un espacement uniforme entre les traits quelle que soit la taille du bouton

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da73b2a440832e8540fddbf5e8d5c7