### PR TITLE
Structurer les conseils experts en deux volets

### DIFF
--- a/card_discussion.html
+++ b/card_discussion.html
@@ -114,9 +114,9 @@
       <card category="Gestion des émotions">
         <content>Ton enfant de 3 ans se met à hurler parce que tu refuses un deuxième biscuit. Quelle première phrase pourrais-tu lui dire pour valider son émotion tout en gardant la limite ?</content>
         <advice>
-          Commence par respirer avec lui et mets-toi à sa hauteur pour maintenir la connexion. Décris ce que tu observes : « Tu es très déçu parce que je dis non au biscuit » puis laisse-lui quelques secondes pour décharger sans jugement.
+          Commence par réguler ton propre tonus (respiration, posture accroupie) et valider l’émotion ressentie avant de rappeler la règle. Les situations de frustration partagent le même besoin : nommer ce qui se passe, dire la limite avec calme et offrir un exutoire acceptable ou une alternative concrète.
 
-          Rappelle ensuite la limite calmement en expliquant le pourquoi : « Notre corps a besoin de faire une pause avec le sucre ». Propose une alternative claire comme un verre d’eau ou un jeu de transition afin qu’il sente qu’il n’est pas laissé seul avec sa frustration.
+          Pour le deuxième biscuit, baisse-toi à sa hauteur, regarde-le et dis : « Tu en voulais encore et c’est dur quand je dis non ». Laisse passer quelques respirations, puis ajoute : « Notre corps a eu assez de sucre, tu peux choisir entre un verre d’eau fraîche ou venir m’aider à ranger la boîte ». Termine en l’accompagnant vers l’option choisie.
         </advice>
         <variations>
           <variation title="Sortie du bain">Ton enfant explose en sanglots parce que tu annonces la fin du bain alors qu’il veut encore jouer avec l’eau. Quelle phrase d’accueil peux-tu utiliser pour reconnaître sa déception tout en gardant la limite ?</variation>
@@ -126,9 +126,9 @@
       <card category="Coopération quotidienne">
         <content>Au moment de se brosser les dents, ton enfant se cache sous la table en criant « Non ! ». Comment pourrais-tu reformuler la consigne pour créer une alliance et avancer ensemble ?</content>
         <advice>
-          Utilise un ton ludique et descriptif : « J’ai deux brosses super-héros qui cherchent un volontaire, laquelle choisissons-nous ? ». Cette reformulation réintroduit le jeu et lui permet de se sentir acteur plutôt qu’opposé.
+          Quand la coopération bloque, reformule la consigne en décrivant ce qui est attendu et en y ajoutant un levier ludique ou un micro-choix. Ces ressorts conviennent à la plupart des routines : annoncer la tâche, l’habiller d’une histoire, puis donner deux options gagnantes pour que l’enfant reste engagé.
 
-          Offre un micro-choix pour restaurer son sentiment de contrôle : « Tu préfères que je commence par les dents du haut ou du bas ? ». En l’invitant dans la tâche, tu maintiens la limite tout en nourrissant l’alliance.
+          Sous la table pour le brossage de dents, transforme la scène : « Les brosses super-héros ont besoin d’un copilote, tu préfères piloter la bleue ou la verte ? ». Reste accroupi, tends la brosse choisie et propose : « On commence par les dents du haut ou tu veux que je fasse le décompte ? ». Accompagne-le jusqu’à la fin en gardant la narration ludique.
         </advice>
         <variations>
           <variation title="Enfiler le pyjama">À l’heure d’enfiler son pyjama, ton enfant se cache derrière le canapé et refuse de sortir. Quelle proposition ludique pourrais-tu inventer pour transformer la consigne en jeu coopératif ?</variation>
@@ -138,9 +138,9 @@
       <card category="Frustration et apprentissages">
         <content>Après avoir perdu à un jeu de société, ton enfant renverse le plateau. Quelle invitation à la réflexion pourrais-tu lui proposer pour l’aider à nommer sa frustration ?</content>
         <advice>
-          Valide d’abord son vécu avant de chercher une solution : « Tu aurais aimé gagner et c’est dur quand la partie s’arrête comme ça ». Reste près de lui physiquement pour qu’il sente que tu accueilles son émotion.
+          Après un échec vécu intensément, commence par valider l’émotion et offrir une présence stable avant d’aborder la réflexion. Les temps de débrief se structurent bien en trois étapes : observation (« tu aurais aimé… »), accueil du ressenti, puis co-construction d’outils utiles pour les prochaines fois.
 
-          Quand l’intensité baisse, propose une question ouverte : « Qu’est-ce qui t’aiderait la prochaine fois quand tu sens la colère arriver ? ». Encourage-le à imaginer une stratégie concrète (respirer, demander une pause, serrer un coussin) et co-créez un plan pour la prochaine partie.
+          Quand le plateau est renversé, reste à côté de lui et dis calmement : « Tu espérais gagner et tout s’est arrêté d’un coup ». Une fois la tempête passée, invite-le à réfléchir : « Pour la prochaine partie, qu’est-ce qui pourrait t’aider quand la colère monte ? On note une idée à tester ? ». Propose-lui d’écrire ou de dessiner la stratégie choisie et de la garder pour votre prochain jeu.
         </advice>
         <variations>
           <variation title="Concours de dessin">Lors d’un concours de dessin improvisé avec sa cousine, il froisse sa feuille en disant qu’il est nul. Quelle question pourrait l’aider à mettre des mots sur sa frustration avant de trouver une idée pour recommencer ?</variation>
@@ -150,9 +150,9 @@
       <card category="Rivalités fraternelles">
         <content>Deux frères se disputent la même peluche et commencent à se pousser. Comment pourrais-tu intervenir pour reconnaître les besoins de chacun avant de chercher une solution ?</content>
         <advice>
-          Stoppe le geste en posant une main rassurante entre eux et rappelle la règle de sécurité : « Je vois deux enfants qui veulent la même peluche, et je ne laisserai personne se faire mal ». Parle lentement pour inviter tout le monde à ralentir.
+          Lors d’un conflit entre enfants, sécurise d’abord physiquement la scène, puis rends visibles les besoins de chacun avant de chercher une solution. La méthode fonctionne en trois temps : arrêt du geste, validation des émotions, co-construction d’options équitables.
 
-          Donne la parole à tour de rôle : « J’écoute d’abord Paul, puis Léa ». Reformule leurs besoins (jouer, être rassuré, avoir un tour) puis sollicite leur créativité : « Quelles idées avez-vous pour que chacun soit satisfait ? ». Cette médiation les aide à apprendre la coopération plutôt que l’arbitrage automatique.
+          Pour la peluche convoitée, place calmement ta main entre eux et dis : « Je vois deux enfants qui veulent la même peluche, je garde tout le monde en sécurité ». Invite ensuite Paul à parler pendant que Léa attend son tour, reformule ce que chacun souhaite et propose : « On cherche ensemble une idée pour que chacun soit servi, qui commence ? ». Accompagne-les dans le choix retenu (tour de rôle, minuteur, autre jeu) et observe la mise en place.
         </advice>
         <variations>
           <variation title="Construction de Lego">Deux enfants s’arrachent la même pièce de Lego et la tension monte. Comment pourrais-tu sécuriser la scène et verbaliser le besoin de chacun avant d’imaginer des tours de jeu ?</variation>
@@ -162,9 +162,9 @@
       <card category="Rituels du soir">
         <content>À l’heure du coucher, ton enfant réclame encore une histoire et dit qu’il n’est pas fatigué. Quelle routine apaisante pourrais-tu co-construire pour sécuriser la transition vers le sommeil ?</content>
         <advice>
-          Annonce la fin de journée avec un rituel prévisible : « Dans cinq minutes, nous passerons en mode dodo ». Utilise des repères sensoriels constants (lampe douce, musique calme) pour préparer le corps à ralentir.
+          Les routines du soir gagnent en efficacité lorsqu’elles sont anticipées, stables et co-construites. Préviens l’enfant du passage d’activité, gardez des repères sensoriels constants et séquencez toujours en connexion, histoire partagée, puis autonomie accompagnée.
 
-          Co-créez une séquence en trois temps : moment de connexion (câlin, mini jeu), histoire courte, puis rituel autonome (respiration, massage des mains). En lui donnant un rôle actif dans cette routine, tu facilites l’acceptation de la limite tout en nourrissant la sécurité.
+          Ce soir où il réclame encore une histoire, annonce : « Dans cinq minutes, on passe en mode dodo » tout en diminuant la lumière et en lançant votre musique calme. Propose ensuite votre trio : un câlin ou jeu calme choisi ensemble, une histoire courte décidée à l’avance, puis une respiration guidée où il souffle sur sa peluche. Concluez par un rappel doux : « Tu peux refaire la respiration si tu en as besoin, je reviens te voir dans dix minutes ».
         </advice>
         <variations>
           <variation title="Réveil nocturne">Ton enfant sort de son lit chaque nuit pour réclamer un verre d’eau supplémentaire. Quelle mini routine apaisante pourrais-tu imaginer avec lui pour qu’il retrouve le sommeil en se sentant rassuré ?</variation>
@@ -174,9 +174,9 @@
       <card category="Limites bienveillantes">
         <content>Ton enfant tape son parent quand la frustration monte. Quelle formulation claire et ferme, mais reliée, peux-tu utiliser pour rappeler la règle et proposer une alternative ?</content>
         <advice>
-          Garde un ton posé et rapproche-toi sans agressivité : « Je vois que tu es très en colère, et je ne te laisserai pas taper ». Nomme ce que tu protèges (ton corps, le sien, la relation) pour que la règle fasse sens.
+          Quand un geste inacceptable apparaît, adopte une posture ancrée : rapprochement physique sécurisé, rappel clair de la règle et proposition d’un exutoire compatible avec la sécurité. Cette structure (constat, protection, alternative) peut être appliquée à toute situation similaire.
 
-          Propose immédiatement un geste de substitution : « Tu peux serrer ce coussin ou taper tes pieds par terre pour dire ta colère ». Reste à proximité pour l’aider à traverser l’émotion, puis débriefe plus tard quand tout le monde est revenu au calme.
+          Face aux coups portés sur toi, attrape doucement sa main et dis calmement : « Je vois ta colère, et je protège nos corps, je ne te laisserai pas taper ». Place un coussin ou un tapis à portée et ajoute : « Pour dire ta colère, tu peux serrer ce coussin ou taper tes pieds ici, je reste avec toi ». Reste proche jusqu’à l’accalmie puis propose un moment plus tard pour parler de ce qui l’a déclenchée.
         </advice>
         <variations>
           <variation title="Frère bousculé">Ton enfant lève la main sur son frère lorsque celui-ci refuse de partager un jeu. Quelle phrase claire pourrais-tu utiliser pour protéger chacun tout en offrant un exutoire acceptable ?</variation>
@@ -186,9 +186,9 @@
       <card category="Autonomie accompagnée">
         <content>Il refuse de s’habiller seul mais rejette ton aide. Quel choix limité inspiré de l’éducation positive pourrais-tu offrir pour qu’il se sente compétent ?</content>
         <advice>
-          Valide son besoin d’autonomie : « Tu aimerais y arriver tout seul et en même temps c’est difficile ce matin ». Évite d’imposer ton rythme immédiatement, offre-lui plutôt un espace de réussite progressive.
+          Lorsque l’autonomie devient une source de tension, commence par reconnaître le besoin de faire seul, puis propose un cadre de coopération avec des choix limités. Cette approche fonctionne pour de nombreuses tâches : valider, fractionner, choisir entre deux options aidantes.
 
-          Propose deux options gagnantes : « Tu choisis de mettre le tee-shirt et je t’aide pour le pantalon, ou l’inverse ». En explicitant que vous formez une équipe, il perçoit ton soutien sans se sentir envahi.
+          Devant les vêtements, dis-lui : « Tu veux y arriver tout seul et c’est difficile ce matin, je comprends ». Ouvre ensuite deux pistes : « Tu préfères enfiler le tee-shirt pendant que je tiens le col, ou tu commences par le pantalon et je t’aide pour les boutons ? ». Encourage-le à décider, reste tout près pour soutenir le choix retenu et conclue par une valorisation : « On a formé une super équipe pour t’habiller ».
         </advice>
         <variations>
           <variation title="Se coiffer">Il refuse que tu l’aides à se coiffer mais n’arrive pas à démêler ses cheveux seul. Quel choix limité pourrais-tu lui proposer pour préserver son autonomie tout en l’accompagnant ?</variation>
@@ -198,9 +198,9 @@
       <card category="Transitions douces">
         <content>Au parc, il est l’heure de partir mais ton enfant crie qu’il veut rester. Quelle stratégie d’anticipation ou de fermeture positive pourrais-tu proposer pour respecter le cadre sans rupture brutale ?</content>
         <advice>
-          Préviens quelques minutes avant le départ avec un signal clair : « Encore deux tours de toboggan et nous partons ». Laisse-le choisir comment vivre ces deux tours pour renforcer son sentiment de maîtrise.
+          Les transitions gagnent à être annoncées, ritualisées et reliées à une perspective positive. Utilise systématiquement le trio anticipation claire, clôture symbolique, puis projection vers l’étape suivante pour éviter les ruptures brusques.
 
-          À l’heure dite, invite-le à un rituel de clôture : remercier le parc, saluer un copain ou prendre une photo mentale. Ensuite, propose une perspective agréable pour la suite (choisir la musique de la voiture, raconter son moment préféré). Cette continuité l’aide à changer d’activité sans se sentir arraché.
+          Au parc, préviens : « Encore deux tours de toboggan et ensuite on part » en le laissant décider comment les vivre. Quand le moment arrive, agenouille-toi près de lui pour dire au revoir au toboggan ou remercier le parc, puis propose : « Sur le chemin, tu choisis la musique et tu me racontes ton meilleur moment ». Accompagne-le physiquement vers la sortie en gardant ce fil conducteur.
         </advice>
         <variations>
           <variation title="Fin de séance de piscine">À la piscine, il refuse de sortir de l’eau quand l’heure de la douche arrive. Quelle anticipation et quel geste de clôture pourrais-tu mettre en place pour rendre la transition plus douce ?</variation>
@@ -210,9 +210,9 @@
       <card category="Communication émotionnelle">
         <content>Ton enfant te dit « je te déteste » après un refus. Quelle réponse pourrait témoigner de ton ancrage et ouvrir un dialogue sur ce qu’il ressent vraiment ?</content>
         <advice>
-          Reçois ses mots sans les prendre personnellement : « Tu es tellement fâché que tu dis des mots très forts ». Ta stabilité lui montre que l’émotion peut être exprimée sans que la relation se brise.
+          Quand des paroles blessantes surgissent, garde une posture stable : constate l’émotion exprimée, montre que le lien reste solide et ouvre un espace pour préciser le besoin réel. Ce schéma d’accueil-décodage-recadre fonctionne pour toutes les variations de messages forts.
 
-          Invite-le à préciser ce qui se passe dedans : « Qu’est-ce qui te pique autant ? » ou « De quoi aurais-tu besoin maintenant ? ». Lorsque le calme revient, explique que toutes les émotions sont bienvenues mais que vous cherchez ensemble des mots qui respectent chacun.
+          Après le « je te déteste », ancre-toi, respire et réponds : « Tu es tellement fâché que tu utilises des mots très forts, je t’entends ». Reste près de lui, puis propose : « Qu’est-ce qui te pique autant ? De quoi tu aurais besoin maintenant ? ». Une fois le calme revenu, reformule : « On peut dire quand on est en colère, cherchons des mots qui respectent chacun » et envisagez ensemble une prochaine fois.
         </advice>
         <variations>
           <variation title="Porte claquée">Après que tu as posé une limite d’écran, il claque la porte en criant « Tu es la pire maman du monde ! ». Quelle réponse ancrée pourrais-tu donner pour accueillir son émotion sans l’escalader ?</variation>
@@ -222,9 +222,9 @@
       <card category="Empathie sociale">
         <content>Il revient de l’école triste car un camarade ne veut plus jouer avec lui. Comment l’aider à accueillir sa peine tout en explorant ce dont il a besoin pour se sentir soutenu ?</content>
         <advice>
-          Accueille sa tristesse avant de chercher une solution : « C’est douloureux quand un ami s’éloigne, je suis là ». Encourage-le à raconter la scène pour qu’il puisse la digérer émotionnellement.
+          Quand un enfant est blessé socialement, sécurise d’abord l’espace émotionnel : nommer la peine, écouter le récit, puis chercher avec lui ce qui pourrait le soutenir. Cette démarche (accueil, expression, pistes d’action) s’adapte à la plupart des situations relationnelles.
 
-          Demande-lui ce qui l’aiderait : un câlin, du temps seul, ou réfléchir à une invitation. Ensuite, explore ensemble différentes options (parler au camarade, proposer un autre jeu, demander de l’aide à l’enseignant) pour qu’il retrouve du pouvoir d’agir.
+          De retour d’école, installez-vous côte à côte et dis : « C’est douloureux quand un ami ne veut plus jouer, je suis là ». Laisse-le raconter ce qui s’est passé, puis demande : « Qu’est-ce qui t’aiderait maintenant, un câlin, du temps pour souffler, ou on réfléchit à une idée ensemble ? ». Enfin, envisagez ensemble un pas concret, par exemple proposer un autre jeu demain ou en parler à l’enseignant.
         </advice>
         <variations>
           <variation title="Invitation refusée">Il raconte qu’aucun camarade n’a voulu venir à son anniversaire. Comment peux-tu accueillir sa peine et l’aider à identifier le soutien dont il a besoin ?</variation>
@@ -234,9 +234,9 @@
       <card category="Réparation et responsabilité">
         <content>Ton enfant casse volontairement le dessin de sa sœur. Quelle conversation pourrais-tu amorcer pour l’accompagner vers la réparation plutôt que la punition ?</content>
         <advice>
-          Mets en pause l’élan punitif et décris factuellement : « Le dessin de ta sœur est déchiré et elle est très déçue ». Vérifie ce qu’il se passait pour lui juste avant l’acte afin de comprendre l’émotion sous-jacente.
+          Face à un dommage causé volontairement, privilégie une approche restaurative : décrire les faits sans jugement, explorer ce qui a motivé le geste, puis rechercher une réparation concrète. Ce triptyque (constat, compréhension, réparation) convient à de nombreuses situations.
 
-          Parlez ensuite de réparation : « Que peux-tu faire pour prendre soin de sa sœur et de votre lien ? ». Laisse-le proposer (recoller, refaire un dessin, offrir un temps ensemble) et soutiens-le dans la mise en œuvre pour qu’il expérimente la responsabilité plutôt que la honte.
+          En voyant le dessin déchiré, dis calmement : « Le dessin de ta sœur est en morceaux et elle est très déçue ». Invite-le à raconter ce qu’il ressentait juste avant, puis demande : « Comment pourrais-tu prendre soin d’elle et de votre lien maintenant ? ». Soutiens la solution choisie (recoller, refaire un dessin, partager un temps spécial) et accompagne-la jusqu’au bout pour valider la réparation.
         </advice>
         <variations>
           <variation title="Tour de blocs détruit">Il renverse exprès la tour de blocs que son frère vient de finir. Quelle discussion pourrais-tu entamer pour nommer les faits et ouvrir sur la réparation ?</variation>
@@ -246,9 +246,9 @@
       <card category="Participation aux tâches">
         <content>Chaque matin, il refuse de mettre son bol dans l’évier. Quelle manière ludique pourrais-tu co-créer pour transformer la consigne en responsabilité valorisante ?</content>
         <advice>
-          Transforme la consigne en mission : « J’ai besoin du chef des bols pour lancer le lave-vaisselle, tu es partant ? ». Un rituel nommé (mission fusée, équipe service) valorise sa participation.
+          Pour encourager la participation, transforme la tâche en rôle valorisant et rends visibles les effets positifs de son action. Les rituels de mission, les titres symboliques et les célébrations relationnelles fonctionnent quelle que soit la corvée.
 
-          Instaurez ensemble un tableau de réussite relationnelle : au lieu de récompenses matérielles, propose un moment de partage quand la mission est remplie (danse du matin, tape dans la main). Il sent alors que sa contribution compte réellement pour la famille.
+          Chaque matin, annonce : « On cherche le capitaine des bols pour lancer la journée, partant ? ». Attribue-lui un signe distinctif (tablier, badge aimanté), montre le trajet jusqu’à l’évier puis concluez par un geste de célébration (tape dans la main, danse de dix secondes). Notez le rôle sur un petit tableau pour rappeler son importance.
         </advice>
         <variations>
           <variation title="Ranger les chaussures">Après l’école, il laisse ses chaussures au milieu du couloir. Quelle mission valorisante pourrais-tu inventer pour l’encourager à les ranger volontairement ?</variation>
@@ -258,9 +258,9 @@
       <card category="Gestion de ta propre émotion">
         <content>Tu sens la colère monter après une succession de refus. Quelle phrase d’auto-coaching ou micro-pause peux-tu utiliser pour revenir dans une présence calme avant de répondre ?</content>
         <advice>
-          Offre-toi une pause consciente : pose la main sur ton ventre et inspire profondément en te disant « Je peux ralentir et choisir ma réponse ». Ce micro-rituel signale à ton corps que tu reprends les commandes.
+          Quand ta propre émotion monte, installe un rituel de régulation en deux temps : signal corporel (ancrage, respiration, mouvement) puis message intérieur qui te rappelle ton intention éducative. Ce combo s’applique à toutes les scènes chargées.
 
-          Si besoin, verbalise à ton enfant : « J’ai besoin de quelques secondes pour me calmer et revenir te voir ». En modélisant cette autorégulation, tu lui montres que prendre soin de ses émotions est une compétence à cultiver ensemble.
+          Après la succession de refus, pose ta main sur ton ventre, inspire en comptant jusqu’à quatre, expire plus lentement et répète intérieurement : « Je peux ralentir et choisir ma réponse ». Dis ensuite à ton enfant : « J’ai besoin de quelques secondes pour me calmer et je reviens te répondre ». Reviens vers lui une fois apaisé pour traiter la situation.
         </advice>
         <variations>
           <variation title="Fin de journée chargée">Après une journée de travail intense, tu te sens à bout quand ton enfant renverse son verre. Quelle auto-instruction ou pause brève peux-tu t’accorder avant de réagir ?</variation>
@@ -270,9 +270,9 @@
       <card category="Usage des écrans">
         <content>Ton enfant réclame « encore cinq minutes » de dessin animé et la négociation dégénère. Comment poser un cadre clair tout en proposant un plan de sortie qui respecte vos besoins ?</content>
         <advice>
-          Clarifie le cadre à froid : définissez à l’avance le nombre d’épisodes ou le minuteur, et annonce l’approche de la fin quelques minutes avant l’arrêt effectif. Ainsi, l’enfant sait à quoi s’attendre.
+          La gestion des écrans repose sur un cadre préparé à l’avance, une anticipation claire de la fin et une transition qui engage l’enfant ailleurs. Ce trio prévisibilité-rappel-activité passerelle convient à la plupart des usages numériques.
 
-          Au moment de couper, propose une activité passerelle : choisir une chanson, préparer le goûter, bouger le corps. Rappelle que la limite est non négociable tout en reconnaissant sa frustration : « Tu voulais continuer, c’est difficile de s’arrêter, je suis avec toi ».
+          Quand il réclame « encore cinq minutes », rappelle le cadre défini : « On avait prévu un épisode, le minuteur sonne ». Accroupis-toi, valide : « Tu voudrais continuer, c’est difficile de s’arrêter ». Propose aussitôt la passerelle choisie ensemble (mettre la table du goûter, sélectionner la musique de la voiture) et accompagne-le dans ce nouveau geste en restant présent.
         </advice>
         <variations>
           <variation title="Jeu vidéo">Pendant un jeu vidéo, il proteste quand tu annonces la fin de la partie. Quelle anticipation et quel plan de sortie pourrais-tu mettre en place pour rendre la coupure plus sereine ?</variation>
@@ -282,9 +282,9 @@
       <card category="Partenariat avec l’école">
         <content>L’enseignant signale que ton enfant coupe souvent la parole en classe. Quelle discussion à la maison pourrait encourager la conscience de soi et l’écoute active ?</content>
         <advice>
-          Partage l’information sans accusation : « Ton enseignant m’a dit que tu as beaucoup d’idées et qu’il est parfois difficile de laisser les autres parler ». Invite-le à raconter sa version pour qu’il se sente entendu.
+          Pour coopérer avec l’école, adopte un dialogue en trois temps : transmettre le retour de l’adulte sans jugement, écouter la perspective de l’enfant, puis co-créer des stratégies concrètes qu’il pourra appliquer. Cette démarche renforce l’alliance école-famille dans diverses situations.
 
-          Explore avec lui des stratégies d’autorégulation : lever la main, compter jusqu’à trois, noter son idée. Envisagez ensemble un signe discret avec l’enseignant ou un carnet d’idées. En l’impliquant dans le plan, tu développes son sentiment de compétence sociale.
+          Concernant les prises de parole en classe, explique-lui : « Ton enseignant dit que tu as beaucoup d’idées et que c’est parfois difficile de laisser de la place aux autres ». Laisse-le raconter comment il vit ces moments, puis propose : « On cherche trois outils ? Lever la main, compter jusqu’à trois, noter ton idée ». Décidez ensemble d’un signe discret avec l’enseignant et préparez un petit carnet pour noter ses idées en attendant son tour.
         </advice>
         <variations>
           <variation title="Participation en groupe">L’animateur du centre de loisirs t’informe qu’il interrompt souvent les autres. Quelle conversation pourrais-tu ouvrir pour réfléchir ensemble à des outils d’écoute ?</variation>
@@ -294,9 +294,9 @@
       <card category="Motivation intrinsèque">
         <content>Ton enfant rechigne à faire ses devoirs sans récompense. Comment pourrais-tu l’aider à identifier ce qui rend l’apprentissage important pour lui, plutôt que d’imposer une carotte ?</content>
         <advice>
-          Relie la tâche à ses projets : « Qu’aimes-tu faire qui nécessite de savoir lire/compter ? ». Discuter de ses passions (bandes dessinées, expériences scientifiques, bricolage) donne du sens à l’effort.
+          Pour soutenir la motivation intrinsèque, relie la tâche au projet personnel de l’enfant, clarifie les compétences que cela nourrit, puis valorise le processus plutôt que le résultat. Cette méthode s’adapte aux apprentissages scolaires comme extrascolaires.
 
-          Fractionnez le travail en objectifs atteignables avec des pauses choisies ensemble. Félicite le processus (persévérance, stratégies utilisées) plutôt que le résultat pour renforcer la fierté intrinsèque.
+          Face aux devoirs refusés, discute de ce qu’il aime : « Tu adores lire des BD et construire tes jeux, voilà pourquoi on s’entraîne à lire et compter ». Découpez le travail en petites étapes avec un minuteur choisi ensemble et prévoyez une courte pause active entre chaque bloc. À la fin, souligne : « J’ai vu ta persévérance et la stratégie que tu as utilisée pour ce problème, bravo pour l’effort ».
         </advice>
         <variations>
           <variation title="Instrument de musique">Il boude son entraînement de piano sans récompense. Comment pourrais-tu relier la pratique à ce qui le motive vraiment et l’aider à choisir ses propres objectifs ?</variation>
@@ -306,9 +306,9 @@
       <card category="Gestion du stress parental">
         <content>Tu te sens submergé par les pleurs du soir et crains de perdre patience. Quel rituel de connexion courte pourrais-tu instaurer pour nourrir le lien avant d’aborder le problème ?</content>
         <advice>
-          Avant la crise, prévois un rituel ancre : cinq minutes de câlin silencieux, une chanson douce ou un massage des mains. Ce moment nourrit ta propre réserve émotionnelle et rassure ton enfant.
+          Pour gérer ton stress parental, planifie des ressources avant les moments critiques : micro-rituel de connexion, respiration partagée, relais possible. Ce duo anticipation-soutien reste valable quelle que soit la configuration familiale.
 
-          Identifie ensuite un co-régulateur possible (partenaire, proche, respiration guidée) pour t’accorder un relais lorsque la tension monte. Plus tu anticipes tes besoins de soutien, plus tu peux rester disponible sans te sacrifier.
+          Le soir avant les pleurs, bloque cinq minutes de câlin ou de respiration ensemble sur le canapé. Préviens ton partenaire ou un proche qu’il peut prendre le relais dix minutes si la tension grimpe et prépare ta propre ressource (verre d’eau, respiration guidée dans des écouteurs). Tu arrives ainsi dans la séquence du soir avec un réservoir émotionnel plus plein.
         </advice>
         <variations>
           <variation title="Matins précipités">Les matins sont tendus et tu crains de t’emporter. Quel micro-rituel de connexion pourrais-tu planifier avant la course pour abaisser ton stress et nourrir le lien ?</variation>
@@ -318,9 +318,9 @@
       <card category="Courses au supermarché">
         <content>Au magasin, ton enfant se roule par terre pour obtenir une friandise. Quelle démarche en trois temps (connexion, limite, solution) pourrais-tu appliquer sur le moment ?</content>
         <advice>
-          Connecte-toi d’abord à son vécu : mets-toi à sa hauteur et reconnais son envie « Tu la trouves très tentante cette friandise ! ». Le simple fait d’être vu apaise souvent l’intensité.
+          Dans un lieu public, applique une démarche en trois temps : connexion empathique, rappel clair de la limite, puis redirection vers une action concrète. Cette structure aide à rester ferme tout en accompagnant l’émotion, quelle que soit la variation.
 
-          Réaffirme ensuite la limite : « Aujourd’hui nous n’achetons pas de bonbon » tout en proposant une alternative préparée (choisir le fruit du goûter, noter la friandise pour une autre occasion). Terminez par une action concrète pour le remettre en mouvement : porter la liste, aider à scanner un article, respirer ensemble.
+          Au supermarché, accroupis-toi près de lui et reconnais : « Cette friandise te fait très envie ». Maintiens la limite : « Aujourd’hui nous n’achetons pas de bonbon » et propose l’alternative prévue : « Tu peux choisir le fruit du goûter ou noter ce bonbon sur notre liste d’idées ». Confie-lui ensuite une mission immédiate, comme porter la liste ou scanner les articles, pour le remettre en mouvement.
         </advice>
         <variations>
           <variation title="Rayon jouets">Devant le rayon jouets, il s’accroche à une boîte en criant qu’il la veut absolument. Comment pourrais-tu suivre les trois temps connexion-limite-solution dans cette situation ?</variation>
@@ -330,9 +330,9 @@
       <card category="Questions existentielles">
         <content>Ton enfant de 5 ans te demande si Mamie va mourir bientôt. Comment répondre avec honnêteté et douceur tout en accueillant ses émotions ?</content>
         <advice>
-          Réponds avec des mots simples et vrais : « Tout le monde meurt un jour, et nous ne savons pas quand. Pour l’instant Mamie est vivante et nous pouvons profiter d’elle ». Évite les promesses impossibles tout en restant rassurant.
+          Les questions existentielles appellent une réponse honnête, simple et adaptée à l’âge, suivie d’un espace pour accueillir les émotions. Garde le schéma vérité claire, reconnaissance du ressenti, puis proposition d’un geste qui relie.
 
-          Autorise ses émotions : « C’est normal que cette question fasse peur ou rende triste ». Propose-lui une action réconfortante (dessiner pour Mamie, regarder des photos, faire un câlin) afin de transformer l’angoisse en lien.
+          Pour la question sur Mamie, réponds : « Tout le monde meurt un jour et on ne sait pas quand. Aujourd’hui Mamie est vivante et on profite d’elle ». Observe sa réaction, ajoute : « C’est normal que ça fasse peur ou que tu sois triste » et propose : « On ferait un dessin pour elle ou on regarde des photos ensemble ? ». Offre ta présence physique pendant qu’il choisit.
         </advice>
         <variations>
           <variation title="Animaux de compagnie">Ton enfant demande si votre chat va mourir bientôt. Comment peux-tu répondre avec clarté et douceur tout en accueillant ce que cela lui fait ?</variation>
@@ -342,9 +342,9 @@
       <card category="Matins pressés">
         <content>Les départs à l’école sont chaotiques et se terminent en cris. Quelle stratégie de préparation la veille et de choix partagés pourrait fluidifier la routine ?</content>
         <advice>
-          Préparez ensemble la veille : vêtements choisis, sac vérifié, tableau visuel des étapes du matin. Plus il participe à l’organisation, plus il se sent copropriétaire de la routine.
+          Pour des matins fluides, combinez préparation la veille, repères visuels et choix limités. Ce duo anticipation-autorisation de choisir s’applique à toutes les variantes de départs pressés.
 
-          Le matin, donne des repères temporels et des choix limités (« Tu mets d’abord les chaussures ou tu finis ton petit-déjeuner ? »). Un minuteur visuel ou une playlist de durée fixe peut aussi servir de guide externe pour garder le calme.
+          Avant de dormir, préparez ensemble les vêtements, vérifiez le sac et affichez un tableau avec les étapes du matin. Au réveil, rappelle le planning : « Quand cette chanson se termine, on met les chaussures. Tu commences par elles ou tu finis ton petit-déjeuner ? ». Utilise un minuteur visuel ou une playlist calibrée pour maintenir le rythme sans crier.
         </advice>
         <variations>
           <variation title="Départ chez la nounou">Les matins où il faut aller chez la nounou, tout traîne. Quelle anticipation la veille et quels choix partagés pourrais-tu instaurer pour alléger le départ ?</variation>
@@ -354,9 +354,9 @@
       <card category="Arrivée du bébé">
         <content>Tu attends un nouveau-né et ton aîné s’inquiète de perdre sa place. Quelle conversation anticipatrice pourrais-tu avoir pour nourrir son besoin de sécurité et de contribution ?</content>
         <advice>
-          Valide ses peurs : « Tu te demandes si j’aurai encore du temps pour toi, c’est important pour toi ». Partage concrètement comment vous passerez du temps ensemble, même après l’arrivée du bébé.
+          Quand la famille s’agrandit, rassure en nommant les émotions, montre comment le lien sera préservé et offre un rôle concret. Cette combinaison sécurité-affection-contribution soutient l’aîné quelles que soient les variantes.
 
-          Implique-le dans la préparation avec des tâches valorisantes adaptées à son âge (choisir un vêtement, préparer une chanson). En lui confiant un rôle de grand allié, tu transformes l’inquiétude en sentiment de contribution.
+          Explique-lui : « Tu te demandes si j’aurai encore du temps pour toi, c’est important pour toi ». Décrivez ensemble un moment privilégié quotidien après la naissance (histoire du soir, promenade). Confie-lui une mission valorisante : préparer la boîte à chansons du bébé ou choisir un pyjama, puis planifiez un rendez-vous spécial à deux dans le calendrier.
         </advice>
         <variations>
           <variation title="Premier jour à la maternité">Il redoute de ne pas te voir pendant ton séjour à la maternité. Quelle discussion rassurante pourrais-tu avoir pour lui expliquer le déroulé et sa place ?</variation>
@@ -366,9 +366,9 @@
       <card category="Apaiser un nourrisson">
         <content>Ton futur bébé pleure malgré le change et le repas. Quelles étapes d’observation et de co-régulation peux-tu prévoir pour rester présent et empathique ?</content>
         <advice>
-          Passe en revue calmement les besoins de base (faim, fatigue, confort, contact). Observe son corps pour repérer des signes de tension ou de douleur et ajuste l’environnement (lumière, bruit, température).
+          Pour apaiser un nourrisson, applique une vérification systématique des besoins de base, ajuste l’environnement, puis engage une co-régulation sensorielle (contact, mouvement, son). Ce protocole reste pertinent quelles que soient les circonstances des pleurs.
 
-          Installe un rituel de co-régulation : peau à peau, bercements lents, respiration synchronisée. Chante doucement ou parle-lui pour l’ancrer dans ta présence. Même si les pleurs persistent, ton calme l’aide à sentir qu’il n’est pas seul.
+          Quand ton bébé pleure malgré le change et le repas, passe en revue faim, fatigue, confort thermique puis observe ses tensions. Réduis la lumière, place-le en peau à peau ou contre ton torse, balance-le doucement et synchronise ta respiration avec la sienne en murmurant une phrase rassurante répétitive. Reste présent quelques minutes pour laisser le calme se diffuser.
         </advice>
         <variations>
           <variation title="Balade en poussette">En promenade, ton nourrisson pleure sans raison apparente. Quelles étapes d’observation et de co-régulation peux-tu suivre pour rester présent ?</variation>
@@ -378,9 +378,9 @@
       <card category="Réseau familial">
         <content>Un grand-parent minimise tes limites et offre des friandises en cachette. Comment poser une limite adulte à adulte tout en préservant la relation ?</content>
         <advice>
-          Choisis un moment hors présence des enfants pour en parler. Utilise le « je » : « Quand les friandises sont données après que j’ai dit non, je me sens décrédibilisée et cela complique notre routine ».
+          Avec la famille élargie, vise un échange adulte à adulte : choisir le bon moment, parler en « je », rappeler l’objectif commun puis proposer une alternative qui respecte la limite. Cette méthode s’applique à différentes divergences éducatives.
 
-          Réaffirme votre objectif commun (le bien-être de l’enfant) et propose une alternative claire : « Si tu veux lui faire plaisir, nous pouvons prévoir ensemble un goûter spécial le mercredi ». Cette discussion posée rappelle le cadre tout en reconnaissant sa volonté d’être généreux.
+          Concernant les friandises, aborde le sujet hors présence des enfants : « Quand tu donnes des douceurs après que j’ai dit non, je me sens moins crédible et ça complique notre routine ». Souligne : « On veut tous les deux son bien-être ». Propose ensuite : « Et si on prévoyait ensemble un goûter spécial le mercredi ? ». Validez la solution et remerciez son implication.
         </advice>
         <variations>
           <variation title="Temps d’écran chez les grands-parents">Les grands-parents autorisent des écrans sans te prévenir. Comment pourrais-tu poser le cadre avec eux pour rester aligné sur vos objectifs communs ?</variation>
@@ -390,9 +390,9 @@
       <card category="Moments de connexion">
         <content>Tu sens que les obligations prennent le dessus et que les moments de jeu se raréfient. Quelle micro-activité de connexion quotidienne pourrais-tu instaurer pour recharger le lien ?</content>
         <advice>
-          Identifie un moment clé (réveil, retour d’école, coucher) et consacre-y un rituel court mais exclusif : cinq minutes de jeu du regard, une danse improvisée, un récit « le meilleur/le plus drôle de la journée ».
+          Pour nourrir le lien, choisis un moment récurrent, crée un rituel court et exclusif, puis protège-le comme un rendez-vous important. Cette formule moment-clé + micro-activité + engagement fonctionne quel que soit l’emploi du temps.
 
-          Note-le dans ton agenda comme un rendez-vous non négociable. En célébrant ce temps partagé, même bref, tu nourris la complicité et rends les obligations moins lourdes pour toute la famille.
+          Si les jeux se raréfient, repérez un créneau fixe (par exemple après le goûter), annonce : « C’est notre cinq minutes de connexion ». Lancez une mini-activité choisie ensemble (jeu du regard, carte des moments préférés) et notez-la dans votre agenda familial. Terminez en célébrant ce rendez-vous : « J’adore ce moment juste pour nous » pour renforcer votre complicité.
         </advice>
         <variations>
           <variation title="Lien en fratrie">Tu aimerais renforcer la connexion entre tes deux enfants malgré des emplois du temps chargés. Quelle micro-activité quotidienne pourrais-tu proposer pour nourrir leur lien ?</variation>


### PR DESCRIPTION
## Summary
- restructure les textes de recommandations pour introduire un premier paragraphe générique suivi d'une mise en œuvre spécifique à chaque situation
- harmonise toutes les cartes pour que les conseils soient applicables aux variantes tout en détaillant l'exemple de base

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab2b0ef88832e9a8e29cf580f2a8c