### PR TITLE
Refine expert recommendation favorite toggle

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -471,6 +471,121 @@ body{
 
 .expert-advice-text p:last-child{ margin-bottom:0; }
 
+.expert-favorite{
+  background:var(--surface-muted);
+  border-radius:14px;
+  padding:18px 18px 26px;
+  border:1px solid rgba(233,146,145,0.25);
+  box-shadow:0 6px 18px rgba(209,133,126,0.18);
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.expert-favorite-text{
+  font-size:0.95rem;
+  line-height:1.55;
+  padding-right:72px;
+}
+
+.favorite-heart{
+  position:absolute;
+  bottom:14px;
+  right:14px;
+  width:46px;
+  height:46px;
+  border-radius:50%;
+  border:2px solid rgba(233,146,145,0.4);
+  background:var(--surface);
+  color:#D27975;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:1.5rem;
+  cursor:pointer;
+  transition:transform .25s ease, box-shadow .25s ease, background .25s ease, color .25s ease, border-color .25s ease;
+  box-shadow:0 6px 16px rgba(209,133,126,0.18);
+}
+
+.favorite-heart:hover,
+.favorite-heart:focus-visible{
+  transform:translateY(-2px) scale(1.05);
+  box-shadow:0 10px 22px rgba(209,133,126,0.28);
+}
+
+.favorite-heart:focus-visible{
+  outline:none;
+  border-color:rgba(233,146,145,0.8);
+}
+
+.favorite-heart.is-favorite{
+  background:var(--accent-grad);
+  color:var(--text-inverse);
+  border-color:transparent;
+  box-shadow:0 12px 26px rgba(244,151,142,0.35);
+}
+
+.favorite-heart .heart-icon{
+  display:inline-block;
+  transition:transform .3s ease, text-shadow .3s ease;
+}
+
+.favorite-heart.favorite-heart-animate .heart-icon{
+  animation:heart-pop .6s ease;
+}
+
+.favorite-heart.favorite-heart-animate::after{
+  content:"";
+  position:absolute;
+  inset:-6px;
+  border-radius:50%;
+  background:radial-gradient(circle, rgba(255,255,255,0.85) 0%, rgba(255,255,255,0) 65%);
+  opacity:0;
+  animation:heart-glow .6s ease;
+  pointer-events:none;
+}
+
+@keyframes heart-pop{
+  0%{ transform:scale(0.8); text-shadow:0 0 0 rgba(255,255,255,0); }
+  45%{ transform:scale(1.25); text-shadow:0 0 18px rgba(255,255,255,0.7); }
+  70%{ transform:scale(0.95); text-shadow:0 0 6px rgba(255,255,255,0.4); }
+  100%{ transform:scale(1); text-shadow:0 0 0 rgba(255,255,255,0); }
+}
+
+@keyframes heart-glow{
+  0%{ opacity:0.9; transform:scale(0.7); }
+  60%{ opacity:0.4; transform:scale(1.2); }
+  100%{ opacity:0; transform:scale(1.5); }
+}
+
+.favorite-heart.favorite-heart-animate::after,
+.favorite-heart.favorite-heart-animate .heart-icon{
+  will-change:transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce){
+  .favorite-heart{
+    transition:none;
+  }
+  .favorite-heart:hover,
+  .favorite-heart:focus-visible{
+    transform:none;
+    box-shadow:0 6px 16px rgba(209,133,126,0.18);
+  }
+  .favorite-heart.favorite-heart-animate .heart-icon,
+  .favorite-heart.favorite-heart-animate::after{
+    animation:none;
+  }
+}
+
+.expert-favorite-status{
+  font-size:0.9rem;
+  color:#6F5957;
+  min-height:1.4em;
+  padding-right:72px;
+}
+
 .expert-mastery{
   background:var(--surface-muted);
   border-radius:14px;
@@ -525,6 +640,79 @@ body{
   line-height:1.5;
   text-align:center;
   color:#6F5957;
+}
+
+.favorites-modal-content{
+  max-width:680px;
+}
+
+.favorites-list{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+
+.favorites-empty{
+  background:var(--surface-muted);
+  border-radius:12px;
+  padding:18px;
+  border:1px dashed rgba(233,146,145,0.35);
+  text-align:center;
+  color:#9C7A75;
+  font-size:0.95rem;
+}
+
+.favorite-item{
+  background:var(--surface-muted);
+  border-radius:14px;
+  padding:20px;
+  border:1px solid rgba(233,146,145,0.25);
+  box-shadow:0 6px 18px rgba(209,133,126,0.18);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.favorite-title{
+  font-size:1.05rem;
+  color:#C06760;
+  font-weight:700;
+}
+
+.favorite-excerpt{
+  font-size:0.95rem;
+  line-height:1.55;
+  color:#6F5957;
+}
+
+.favorite-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.favorite-actions .btn{
+  flex:1 1 220px;
+  padding:12px 18px;
+  text-transform:none;
+  letter-spacing:0;
+}
+
+.favorite-actions .favorite-open{
+  background:var(--accent-grad);
+  color:var(--text-inverse);
+}
+
+.favorite-actions .favorite-remove{
+  background:var(--surface);
+  color:#C06760;
+  border:2px solid rgba(233,146,145,0.35);
+  box-shadow:none;
+}
+
+.favorite-actions .favorite-remove:hover,
+.favorite-actions .favorite-remove:focus{
+  background:rgba(233,146,145,0.1);
 }
 
 .select-all{

--- a/card_discussion.html
+++ b/card_discussion.html
@@ -57,6 +57,7 @@
       <div class="menu-dropdown" id="advancedMenu" role="menu">
         <button class="btn menu-action" role="menuitem" onclick="resetDeck()">Réinitialiser</button>
         <button class="btn menu-action" id="openThemeSelector" type="button" role="menuitem">Choisir les thématiques</button>
+        <button class="btn menu-action" id="openFavorites" type="button" role="menuitem">Mes favoris experts</button>
         <button class="btn menu-action" id="saveSession" type="button" role="menuitem">Enregistrer la session</button>
         <button class="btn menu-action" id="loadSession" type="button" role="menuitem">Charger une session</button>
       </div>
@@ -93,6 +94,13 @@
         <div class="expert-section-title" id="expertAdviceTitle">Recommandations des experts</div>
         <div class="expert-advice-text" id="expertAdviceContent"></div>
       </div>
+      <div class="expert-favorite" id="expertFavoriteSection">
+        <p class="expert-favorite-text">Gardez cette recommandation sous la main pour vos prochaines sessions.</p>
+        <button class="favorite-heart" id="toggleFavorite" type="button" aria-pressed="false" aria-label="Ajouter cette recommandation aux favoris">
+          <span class="heart-icon" aria-hidden="true">♡</span>
+        </button>
+        <p class="expert-favorite-status" id="favoriteStatus" aria-live="polite"></p>
+      </div>
       <div class="expert-mastery" id="expertMasterySection">
         <div class="expert-section-title">Maîtrise du principe</div>
         <p class="expert-mastery-text">Ce principe vous semble-t-il acquis dans cette situation ?</p>
@@ -104,6 +112,18 @@
       </div>
       <div class="modal-actions">
         <button class="btn btn-primary" id="closeExpertAdvice" type="button">Fermer</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-overlay" id="favoritesModal" aria-hidden="true">
+    <div class="modal-content favorites-modal-content" role="dialog" aria-modal="true" aria-labelledby="favoritesTitle">
+      <button class="modal-close" id="closeFavorites" type="button" aria-label="Fermer la liste des favoris">×</button>
+      <h2 class="modal-title" id="favoritesTitle">Mes recommandations favorites</h2>
+      <p class="modal-description">Accédez en un clic aux situations expertes que vous avez enregistrées.</p>
+      <div class="favorites-list" id="favoritesList" role="list"></div>
+      <div class="modal-actions">
+        <button class="btn btn-primary" id="closeFavoritesFooter" type="button">Fermer</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace the expert favorite control with a heart icon tucked into the expert panel corner
- add a playful pop animation with reduced-motion handling for the new heart toggle
- update the favorite logic to sync icon state, aria labels, and animation feedback when saving recommendations

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dabc4d1688832ea4a4cc412ca1ef71