### PR TITLE
Fix expert advice modal height and close behavior

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -397,6 +397,8 @@ body{
   color:var(--text);
   max-width:520px;
   width:100%;
+  max-height:90vh;
+  overflow:auto;
   border-radius:18px;
   padding:30px;
   box-shadow:0 20px 45px rgba(0,0,0,0.25);
@@ -888,8 +890,6 @@ body{
   .modal-content{
     max-width:100%;
     padding:24px 20px;
-    max-height:90vh;
-    overflow:auto;
   }
 
   .theme-options{

--- a/card_discussion.js
+++ b/card_discussion.js
@@ -649,6 +649,9 @@ class DiscussionCardGame {
       }
     }
     this.updateMasteryControls(targetCard);
+    if(this.expertAdviceModalEl && this.expertAdviceModalEl.classList.contains('visible')){
+      this.hideExpertAdvice();
+    }
   }
 
   getBaseCardId(card){


### PR DESCRIPTION
## Summary
- limit the expert advice modal height on larger screens so it remains visible and scrollable, while keeping the mobile styles consistent
- close the expert advice modal automatically after choosing a mastery state so focus returns to the trigger

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad12c25c8832eaa302ea86d053de5