### PR TITLE
Ensure expert modal scroll resets to top

### DIFF
--- a/card_discussion.js
+++ b/card_discussion.js
@@ -600,19 +600,36 @@ class DiscussionCardGame {
   }
 
   scrollExpertAdviceToTop(){
-    if(this.expertAdviceModalEl){
-      if(typeof this.expertAdviceModalEl.scrollTo === 'function'){
-        this.expertAdviceModalEl.scrollTo({ top:0, behavior:'smooth' });
-      }else{
-        this.expertAdviceModalEl.scrollTop = 0;
+    const resetScrollPositions = ()=>{
+      const modalContent = this.expertAdviceModalEl
+        ? this.expertAdviceModalEl.querySelector('.modal-content')
+        : null;
+      const elementsToReset = [
+        this.expertAdviceModalEl,
+        modalContent,
+        this.expertAdviceContentEl
+      ].filter(Boolean);
+
+      elementsToReset.forEach(element=>{
+        if(typeof element.scrollTo === 'function'){
+          try{
+            element.scrollTo({ top:0, behavior:'auto' });
+          }catch(error){
+            element.scrollTo(0,0);
+          }
+        }
+        element.scrollTop = 0;
+      });
+
+      if(modalContent && typeof modalContent.scrollIntoView === 'function'){
+        modalContent.scrollIntoView({ block:'start', inline:'nearest' });
       }
-      const modalContent = this.expertAdviceModalEl.querySelector('.modal-content');
-      if(modalContent){
-        modalContent.scrollTop = 0;
-      }
-    }
-    if(this.expertAdviceContentEl){
-      this.expertAdviceContentEl.scrollTop = 0;
+    };
+
+    if(typeof requestAnimationFrame === 'function'){
+      requestAnimationFrame(()=> requestAnimationFrame(resetScrollPositions));
+    }else{
+      setTimeout(resetScrollPositions,0);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the expert advice modal scroll position resets to the top whenever it opens
- add a deferred scroll reset to catch rendering and browser timing quirks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf2006be8832e9a1e2eddfc495dd3