### PR TITLE
Affichage ciblé des recommandations selon la carte

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -473,6 +473,24 @@ body{
 
 .expert-advice-text p:last-child{ margin-bottom:0; }
 
+.expert-advice-text .advice-section{
+  margin-bottom:18px;
+}
+
+.expert-advice-text .advice-section:last-of-type{
+  margin-bottom:0;
+}
+
+.advice-section-heading{
+  font-weight:600;
+  color:#B26761;
+  margin-bottom:8px;
+}
+
+.advice-section p:last-child{
+  margin-bottom:0;
+}
+
 .expert-favorite{
   background:var(--surface-muted);
   border-radius:14px;


### PR DESCRIPTION
## Summary
- séparer l’affichage des conseils généraux et spécifiques en fonction de la carte consultée
- isoler les variantes pour ne montrer que la recommandation qui correspond à la situation active
- ajouter un léger style aux sections de recommandations pour garder une lecture structurée

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf24db944832eb5f0ce258d99653e