### PR TITLE
Align hamburger icon in advanced menu toggle button

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -271,21 +271,24 @@ body{
   position:relative;
   display:block;
   width:22px;
-  height:14px;
-}
-
-.menu-toggle-icon::before{
-  content:"";
-  position:absolute;
-  top:50%;
-  left:0;
-  width:22px;
   height:2px;
   background:currentColor;
   border-radius:2px;
-  transform:translateY(-50%);
-  box-shadow:0 -6px 0 currentColor, 0 6px 0 currentColor;
 }
+
+.menu-toggle-icon::before,
+.menu-toggle-icon::after{
+  content:"";
+  position:absolute;
+  left:0;
+  width:100%;
+  height:2px;
+  background:currentColor;
+  border-radius:2px;
+}
+
+.menu-toggle-icon::before{ top:-6px; }
+.menu-toggle-icon::after{ top:6px; }
 
 .menu-dropdown{
   position:absolute;


### PR DESCRIPTION
## Summary
- adjust the hamburger toggle styles so the three bars stay perfectly centered in the circular action button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf8f9be68832ebbc6f2ec02ada0f8