### PR TITLE
Adjust mobile menu toggle styling

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -895,17 +895,35 @@ body{
   }
 
   .controls-menu{
-    align-self:flex-end;
+    position:fixed;
+    top:16px;
+    left:16px;
+    align-self:flex-start;
+    z-index:140;
   }
 
   .controls .btn-menu-toggle{
-    width:56px;
+    width:auto;
+    height:auto;
   }
 
   .controls-menu .menu-dropdown{
     width:min(260px, 88vw);
-    right:0;
-    left:auto;
+    left:0;
+    right:auto;
+  }
+
+  .btn-menu-toggle{
+    background:transparent;
+    box-shadow:none;
+    border-radius:0;
+    padding:12px;
+  }
+
+  .btn-menu-toggle:hover,
+  .btn-menu-toggle:focus{
+    background:transparent;
+    color:var(--primary-1);
   }
 
   .modal-content{


### PR DESCRIPTION
## Summary
- move the advanced actions toggle to the top-left on small screens and remove its circular background so only the hamburger lines remain visible
- keep the dropdown anchored to the left edge and preserve hover states without adding a background

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbfcc1ba2c832e9e7e4af8855d2ec2