### PR TITLE
Improve desktop burger menu icon contrast

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -341,6 +341,17 @@ body{
     z-index:120;
   }
 
+  .btn-menu-toggle{
+    color:var(--text);
+  }
+
+  .menu-toggle-icon,
+  .menu-toggle-icon::before,
+  .menu-toggle-icon::after{
+    height:3px;
+    background:var(--text);
+  }
+
   .controls-menu .menu-dropdown{
     top:calc(100% + 16px);
     right:0;


### PR DESCRIPTION
## Summary
- force the desktop menu toggle button to inherit the dark text color
- increase the menu toggle bar thickness and color for better visibility on large viewports

## Testing
- Manual browser test at viewport width ≥ 992px


------
https://chatgpt.com/codex/tasks/task_e_68dc28b73e80832e828247daa3e1b82e