### PR TITLE
Handle delayed cards data loading

### DIFF
--- a/card_discussion.css
+++ b/card_discussion.css
@@ -765,6 +765,17 @@ body{
   padding-right:4px;
 }
 
+.theme-options-empty-message{
+  grid-column:1 / -1;
+  text-align:center;
+  font-weight:600;
+  color:#C06760;
+  background:var(--surface-muted);
+  border-radius:12px;
+  padding:16px 12px;
+  border:1px dashed rgba(233,146,145,0.4);
+}
+
 .theme-option{
   background:var(--surface-muted);
   border-radius:14px;

--- a/cards_data.js
+++ b/cards_data.js
@@ -482,3 +482,33 @@ window.DISCUSSION_CARDS_DATA =
 }
 ]
 ;
+
+(function(){
+  if(typeof window==='undefined' || typeof window.dispatchEvent!=='function'){
+    return;
+  }
+  const data = window.DISCUSSION_CARDS_DATA;
+  const detail = Array.isArray(data)
+    ? data
+    : (data && typeof data==='object' && Array.isArray(data.default) ? data.default : null);
+  if(!detail || detail.length===0){
+    return;
+  }
+  try{
+    const eventName = 'discussionCardsDataReady';
+    if(typeof window.CustomEvent==='function'){
+      window.dispatchEvent(new CustomEvent(eventName, { detail }));
+    }else if(typeof document!=='undefined' && document.createEvent){
+      const evt = document.createEvent('Event');
+      evt.initEvent(eventName, true, true);
+      evt.detail = detail;
+      window.dispatchEvent(evt);
+    }else{
+      const evt = new Event(eventName);
+      evt.detail = detail;
+      window.dispatchEvent(evt);
+    }
+  }catch(error){
+    console.warn('Impossible de signaler le chargement des données de discussion :', error);
+  }
+})();


### PR DESCRIPTION
## Summary
- defer game initialization until both the DOM and discussion card data are available
- show a friendly message and disable theme validation when no data could be loaded yet
- emit a custom event when cards_data.js finishes loading so late scripts can react
- add styles for the empty-state message inside the theme selector

## Testing
- Manual Playwright smoke test

------
https://chatgpt.com/codex/tasks/task_e_68dc33ec700c832ebf2fa20e4cfad92c